### PR TITLE
Add missing file to the extension package

### DIFF
--- a/RVXLiverSegmentation/CMakeLists.txt
+++ b/RVXLiverSegmentation/CMakeLists.txt
@@ -15,6 +15,7 @@ set(MODULE_PYTHON_SCRIPTS
     ${MODULE_NAME}Lib/VesselBranchWizard.py
     ${MODULE_NAME}Lib/VesselSegmentEditWidget.py
     ${MODULE_NAME}Lib/VesselWidget.py
+    ${MODULE_NAME}Lib/VesselHelpWidget.py
     ${MODULE_NAME}Test/__init__.py
     ${MODULE_NAME}Test/ExtractVesselStrategyTestCase.py
     ${MODULE_NAME}Test/ModuleLogicTestCase.py


### PR DESCRIPTION
Fixes the error

from .VesselHelpWidget import VesselHelpWidget, VesselHelpType
ModuleNotFoundError: No module named ‘RVXLiverSegmentationLib.VesselHelpWidget’