### PR TITLE
Fix vessel segmentation on MacOS

### DIFF
--- a/RVXLiverSegmentation/RVXLiverSegmentationLib/DataWidget.py
+++ b/RVXLiverSegmentation/RVXLiverSegmentationLib/DataWidget.py
@@ -41,6 +41,7 @@ class DataWidget(VerticalLayoutWidget):
     self._importButton = None
     self.inputSelector = createInputNodeSelector("vtkMRMLScalarVolumeNode", toolTip="Pick the input.",
                                                  callBack=self.onInputSelectorNodeChanged)
+    self.inputSelector.noneEnabled = True
 
     # Add load DICOM and load DATA button to the layout
     inputLayout.addWidget(self.inputSelector)
@@ -117,8 +118,8 @@ class DataWidget(VerticalLayoutWidget):
     ----------
     node: vtkMRMLNode
     """
-    # Early return if invalid node
-    if not node or node == self._previousNode:
+    # Early return if unchanged node
+    if node == self._previousNode:
       return
 
     self._previousNode = node
@@ -126,7 +127,7 @@ class DataWidget(VerticalLayoutWidget):
 
     # If node not yet properly initialized, attach observer to image change.
     # Else notify image changed and save node as new input volume
-    if node.GetImageData() is None:
+    if node and node.GetImageData() is None:
       self._attachNodeAddedObserverToScene(node)
     else:
       self._notifyInputChanged(node)
@@ -217,13 +218,13 @@ class DataWidget(VerticalLayoutWidget):
     ----------
     volumeNode: vtkMRMLVolumeNode
     """
-    # Early return if invalid volume node
-    if volumeNode is None:
-      return
-
     # hide previous node if necessary
     if self._volumeDisplayNode:
       self._volumeDisplayNode.SetVisibility(False)
+
+    # Early return if invalid volume node
+    if volumeNode is None:
+      return
 
     # Create new display node for input volume
     self._volumeDisplayNode = createDisplayNodeIfNecessary(volumeNode, 'MR-Default')

--- a/RVXLiverSegmentation/RVXLiverSegmentationLib/ExtractVesselStrategies.py
+++ b/RVXLiverSegmentation/RVXLiverSegmentationLib/ExtractVesselStrategies.py
@@ -177,8 +177,8 @@ def mergeVolumes(volumes, volName):
   -------
   Tuple[vtkMRMLVolumeNode, vtkMRMLModelNode]
   """
-  # Extract list of volumes as list of np arrays
-  npVolumes = [slicer.util.arrayFromVolume(volume).astype(int) for volume in volumes]
+  # Extract list of volumes as list of np arrays in int32 format
+  npVolumes = [slicer.util.arrayFromVolume(volume).astype("int32") for volume in volumes]
 
   # Merge all volumes in one
   mergedVol = npVolumes[0]


### PR DESCRIPTION
- Fix volume type to int32 when merging vessels (int on MacOS defaults to int64 which is not supported for Slicer conversion). See #11 & #12
- Add None selection for input volume to avoid problem when loading volume outside of module